### PR TITLE
Add web runner

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,9 +9,10 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-go@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
-          go-version: 1.18
+          go-version: 1.22
       - uses: actions/checkout@v3
 
       - name: Verify dependencies
@@ -38,6 +39,6 @@ jobs:
         run: go test -race -vet=off ./...
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v4
         with:
-          version: v1.45.2
+          version: v1.54

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -91,3 +91,18 @@ linters-settings:
     line-length: 120
   misspell:
     locale: US
+  depguard:
+    rules:
+      main:
+        # Used to determine the package matching priority.
+        # There are three different modes: `original`, `strict`, and `lax`.
+        # Default: "original"
+        list-mode: original
+        # List of file globs that will match this list of settings to compare against.
+        # Default: $all
+        files:
+          - "$all"
+        # List of allowed packages.
+        allow:
+          - $gostd
+          - github.com/farzadghanei/chkok

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -2,16 +2,16 @@
 
 run:
   timeout: 5m
-  go: '1.18'
-  skip-dirs:
-    - .vscode
+  go: '1.22'
+  issues:
+    exclude-dirs:
+      - .vscode
 
 
 linters:
   disable-all: true
   enable:
     - bodyclose
-    - deadcode
     - depguard
     - dogsled
     - dupl
@@ -35,13 +35,11 @@ linters:
     - noctx
     - nolintlint
     - staticcheck
-    - structcheck
     - stylecheck
     - typecheck
     - unconvert
     - unparam
     - unused
-    - varcheck
     - whitespace
 
 issues:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
       - id: end-of-file-fixer
       - id: check-yaml
   - repo: https://github.com/dnephin/pre-commit-golang
-    rev: v0.5.0
+    rev: v0.5.1
     hooks:
       - id: go-fmt
       - id: go-vet

--- a/LICENSE
+++ b/LICENSE
@@ -14,3 +14,29 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
 WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+"Chkok" uses "yaml" Go package, which is released under the terms of the MIT license.
+
+License for yaml
+================
+
+Copyright (c) 2006-2010 Kirill Simonov
+Copyright (c) 2006-2011 Kirill Simonov
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/cmd/chkok.go
+++ b/cmd/chkok.go
@@ -51,9 +51,9 @@ func run(confPath, mode string, output io.Writer, verbose bool) int {
 
 // run app in CLI mode, return exit code
 func runCli(checkGroups *chkok.CheckSuites, conf *chkok.Conf, output io.Writer, logger *log.Logger) int {
-	runner := chkok.Runner{Log: logger}
+	runner := chkok.Runner{Log: logger, Timeout: conf.Runners["default"].Timeout}
 	logger.Printf("running checks ...")
-	checks := runner.RunChecks(*checkGroups, conf.Runners["default"].Timeout)
+	checks := runner.RunChecks(*checkGroups)
 	incompeleteChecks := 0
 	failed := 0
 	for _, chk := range checks {
@@ -79,6 +79,7 @@ func runCli(checkGroups *chkok.CheckSuites, conf *chkok.Conf, output io.Writer, 
 func runHTTP(checkGroups *chkok.CheckSuites, conf *chkok.Conf, output io.Writer, logger *log.Logger) int {
 	httpHandler := func(w http.ResponseWriter, r *http.Request) {
 		logger.Printf("http request: %v", r)
+		// should run the check suites here
 		fmt.Fprintf(w, "Hello, %q", r.URL.Path)
 	}
 	http.HandleFunc("/", httpHandler)

--- a/cmd/chkok.go
+++ b/cmd/chkok.go
@@ -10,22 +10,29 @@ import (
 	"github.com/farzadghanei/chkok"
 )
 
+// ModeHTTP run checks in http server mode
+const ModeHTTP = "http"
+
 func main() {
-	confPath := flag.String("conf", "/etc/chkok.yaml", "path to configuration file")
-	verbose := flag.Bool("verbose", false, "more output, include logs")
+	var confPath string
+	var mode string
+	var verbose bool
+	flag.StringVar(&confPath, "conf", "/etc/chkok.yaml", "path to configuration file")
+	flag.StringVar(&mode, "mode", "cli", "running mode: cli,http")
+	flag.BoolVar(&verbose, "verbose", false, "more output, include logs")
 	flag.Parse()
 
-	os.Exit(run(confPath, os.Stderr, verbose))
+	os.Exit(run(confPath, mode, os.Stderr, verbose))
 }
 
 // run app provided with main arguments, print results to output, return exit code
-func run(confPath *string, output io.Writer, verbose *bool) int {
+func run(confPath, mode string, output io.Writer, verbose bool) int {
 	logger := log.New(io.Discard, "", log.Lshortfile)
-	if *verbose {
+	if verbose {
 		logger.SetOutput(output)
 	}
 
-	conf, err := chkok.ReadConf(*confPath)
+	conf, err := chkok.ReadConf(confPath)
 	if err != nil {
 		fmt.Fprintf(output, "couldn't read YAML configuration file: %v", err)
 		return chkok.ExDataErr
@@ -34,6 +41,9 @@ func run(confPath *string, output io.Writer, verbose *bool) int {
 	if err != nil {
 		fmt.Fprintf(output, "invalid configurations: %v", err)
 		return chkok.ExConfig
+	}
+	if mode == ModeHTTP {
+		return runHTTP(&checkGroups, conf, output, logger)
 	}
 	return runCli(&checkGroups, conf, output, logger)
 }
@@ -61,5 +71,15 @@ func runCli(checkGroups *chkok.CheckSuites, conf *chkok.Conf, output io.Writer, 
 	if failed > 0 {
 		return chkok.ExSoftware
 	}
+	return chkok.ExOK
+}
+
+// run app in http server mode, return exit code
+func runHTTP(checkGroups *chkok.CheckSuites, conf *chkok.Conf, output io.Writer, logger *log.Logger) int {
+	runner := chkok.Runner{Log: logger}
+	logger.Printf("starting http server ...")
+	// @TODO: implement this
+	fmt.Fprintf(output, "TODO: implement this")
+	runner.RunChecks(*checkGroups, conf.Runners["http"].Timeout)
 	return chkok.ExOK
 }

--- a/cmd/chkok.go
+++ b/cmd/chkok.go
@@ -44,7 +44,7 @@ func run(confPath, mode string, output io.Writer, verbose bool) int {
 		return chkok.ExConfig
 	}
 	if mode == ModeHTTP {
-		return runHTTP(&checkGroups, conf, output, logger)
+		return runHTTP(&checkGroups, conf, logger)
 	}
 	return runCli(&checkGroups, conf, output, logger)
 }
@@ -76,7 +76,7 @@ func runCli(checkGroups *chkok.CheckSuites, conf *chkok.Conf, output io.Writer, 
 }
 
 // run app in http server mode, return exit code
-func runHTTP(checkGroups *chkok.CheckSuites, conf *chkok.Conf, output io.Writer, logger *log.Logger) int {
+func runHTTP(checkGroups *chkok.CheckSuites, conf *chkok.Conf, logger *log.Logger) int {
 	runner := chkok.Runner{Log: logger, Timeout: conf.Runners["default"].Timeout}
 	logger.Printf("running checks ...")
 
@@ -100,10 +100,10 @@ func runHTTP(checkGroups *chkok.CheckSuites, conf *chkok.Conf, output io.Writer,
 		}
 		logger.Printf("Run checks done. passed: %v - failed: %v - timedout: %v", passed, failed, incompeleteChecks)
 		if incompeleteChecks > 0 {
-			w.WriteHeader(http.StatusGatewayTimeout)  // 504
+			w.WriteHeader(http.StatusGatewayTimeout) // 504
 			fmt.Fprintf(w, "TIMEDOUT")
 		} else if failed > 0 {
-			w.WriteHeader(http.StatusInternalServerError)  // 500
+			w.WriteHeader(http.StatusInternalServerError) // 500
 			fmt.Fprintf(w, "FAILED")
 		} else {
 			w.WriteHeader(http.StatusOK)

--- a/cmd/chkok.go
+++ b/cmd/chkok.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"net/http"
 	"os"
 
 	"github.com/farzadghanei/chkok"
@@ -76,10 +77,16 @@ func runCli(checkGroups *chkok.CheckSuites, conf *chkok.Conf, output io.Writer, 
 
 // run app in http server mode, return exit code
 func runHTTP(checkGroups *chkok.CheckSuites, conf *chkok.Conf, output io.Writer, logger *log.Logger) int {
-	runner := chkok.Runner{Log: logger}
+	httpHandler := func(w http.ResponseWriter, r *http.Request) {
+		logger.Printf("http request: %v", r)
+		fmt.Fprintf(w, "Hello, %q", r.URL.Path)
+	}
+	http.HandleFunc("/", httpHandler)
 	logger.Printf("starting http server ...")
-	// @TODO: implement this
-	fmt.Fprintf(output, "TODO: implement this")
-	runner.RunChecks(*checkGroups, conf.Runners["http"].Timeout)
+	err := http.ListenAndServe(":8080", nil)
+	if err != nil {
+		logger.Printf("http server failed to start: %v", err)
+		return chkok.ExSoftware
+	}
 	return chkok.ExOK
 }

--- a/cmd/chkok.go
+++ b/cmd/chkok.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"time"
 
 	"github.com/farzadghanei/chkok"
 )
@@ -112,8 +113,16 @@ func runHTTP(checkGroups *chkok.CheckSuites, conf *chkok.Conf, logger *log.Logge
 	}
 
 	http.HandleFunc("/", httpHandler)
+	// TODO: allow to set server timeouts from configuration
+	server := &http.Server{
+		Addr:         ":8080",
+		Handler:      nil, // use http.DefaultServeMux
+		ReadTimeout:  2 * time.Second,
+		WriteTimeout: 5 * time.Second,
+		IdleTimeout:  2 * time.Second,
+	}
 	logger.Printf("starting http server ...")
-	err := http.ListenAndServe(":8080", nil)
+	err := server.ListenAndServe()
 	if err != nil {
 		logger.Printf("http server failed to start: %v", err)
 		return chkok.ExSoftware

--- a/cmd/chkok_test.go
+++ b/cmd/chkok_test.go
@@ -14,8 +14,7 @@ func TestRunCli(t *testing.T) {
 	baseDir, _ := filepath.Abs(filepath.Dir(cwd))
 	writer := bufio.NewWriter(&buf)
 	var confPath = filepath.Join(baseDir, "examples", "test.yaml")
-	verbose := false
-	got := run(&confPath, writer, &verbose)
+	got := run(confPath, "cli", writer, false)
 	if got != 0 {
 		t.Errorf("want exit code 0, got %v. output: %v", got, buf.String())
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/farzadghanei/chkok
 
-go 1.18
+go 1.22
 
 require gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b

--- a/runner.go
+++ b/runner.go
@@ -29,12 +29,14 @@ func (r *Runner) RunChecks(suites CheckSuites, timeout time.Duration) []Check {
 		result = append(result, chk)
 		now = time.Now()
 		if now.Before(deadline) {
+			// adjust timeout for timed checks based on remaining timeout of the runner
 			remaining := deadline.Sub(now)
 			if timedCheck, ok := chk.(TimedCheck); ok {
 				if timedCheck.GetTimeout() > remaining {
 					timedCheck.SetTimeout(remaining)
 				}
 			}
+			// schedule the check to run
 			wg.Add(1)
 			go func() {
 				defer wg.Done()

--- a/runner.go
+++ b/runner.go
@@ -8,7 +8,7 @@ import (
 
 // Runner runs all the checks logging details
 type Runner struct {
-	Log *log.Logger
+	Log     *log.Logger
 	Timeout time.Duration
 }
 

--- a/runner.go
+++ b/runner.go
@@ -9,12 +9,13 @@ import (
 // Runner runs all the checks logging details
 type Runner struct {
 	Log *log.Logger
+	Timeout time.Duration
 }
 
 // RunChecks runs all the checks in the suite and returns slice of check
-func (r *Runner) RunChecks(suites CheckSuites, timeout time.Duration) []Check {
+func (r *Runner) RunChecks(suites CheckSuites) []Check {
 	var now, deadline time.Time
-	deadline = time.Now().Add(timeout)
+	deadline = time.Now().Add(r.Timeout)
 	var checks []Check
 	var wg sync.WaitGroup
 	// TODO: implement check groups sequencial runs, wait for each item

--- a/runner_test.go
+++ b/runner_test.go
@@ -12,8 +12,8 @@ func TestTimedoutRunnerWontSubmitChecks(t *testing.T) {
 	timeout, _ := time.ParseDuration("0s")
 	checks := make(CheckSuites)
 	checks["default"] = []Check{NewCheckFile("examples"), NewCheckDial()}
-	runner := Runner{Log: logger}
-	results := runner.RunChecks(checks, timeout)
+	runner := Runner{Log: logger, Timeout: timeout}
+	results := runner.RunChecks(checks)
 	checkDial := results[1]
 	if checkDial.Status() != StatusUnknown {
 		t.Errorf("wanted 2nd check not run due to timedout")
@@ -28,8 +28,8 @@ func TestTimedoutRunnerAdjustsTimeouts(t *testing.T) {
 	checkDial := NewCheckDial()
 	checkDial.SetTimeout(duration10)
 	checks["default"] = []Check{checkDial}
-	runner := Runner{Log: logger}
-	runner.RunChecks(checks, timeout)
+	runner := Runner{Log: logger, Timeout: timeout}
+	runner.RunChecks(checks)
 	if checkDial.GetTimeout() > timeout {
 		t.Errorf("wanted check dial's timeout adjusted to 1s, got %v", checkDial.GetTimeout())
 	}


### PR DESCRIPTION
Add `http` mode for the runner to start an HTTP server and run the checks upon a web request.

- update lint settings
- update go version from `1.18` to `1.22`
- include license for yaml package