### PR TITLE
Improve default configs, allow config http responses

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,176 @@
+#!/bin/env make -f
+#
+# license: MIT, see LICENSE for details.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+# and associated documentation files (the "Software"), to deal in the Software without restriction,
+# including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+# WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+SHELL = /bin/sh
+makefile_path := $(abspath $(lastword $(MAKEFILE_LIST)))
+makefile_dir := $(dir $(makefile_path))
+CHKOK_VERSION := $(shell grep --perl-regex '^\s*const\s+Version\s+string' cmd/chkok.go | grep --only-matching --perl-regexp '[\d\.]+')
+TIMESTAMP_MINUTE := $(shell date -u +%Y%m%d%H%M)
+
+# build
+OS ?= linux
+ARCH ?= amd64
+DIST ?= bookworm
+GOLDFLAGS ?= "-s"  # by default create a leaner binary
+GOARCH ?= amd64
+
+ifeq ($(ARCH), amd64)
+    GOARCH = amd64
+else ifeq ($(ARCH), i368)
+    GOARCH = 386
+endif
+
+# installation
+DESTDIR ?=
+prefix ?= /usr/local
+exec_prefix ?= $(prefix)
+bindir ?= $(exec_prefix)/bin
+
+# use Make's builtin variable to call 'install'
+INSTALL ?= install
+INSTALL_PROGRAM ?= $(INSTALL)
+INSTALL_DATA ?= $(INSTALL -m 644)
+
+# store current git branch, so after building a package in a temp local branch
+# build process can return to the original branch
+GIT_CURRENT_BRANCH := $(shell git branch --show-current)
+
+# packaging
+SHA256SUM ?= sha256sum -b
+PKG_DIST_DIR ?= $(abspath $(makefile_dir)/..)
+PKG_TGZ_NAME = chkok-$(CHKOK_VERSION)-$(OS)-$(ARCH).tar.gz
+PKG_TGZ_PATH = $(PKG_DIST_DIR)/$(PKG_TGZ_NAME)
+PKG_CHECKSUM_NAME = chkok-$(CHKOK_VERSION)-SHA256SUMS
+PBUILDER_COMPONENTS ?= "main universe"
+PBUILDER_RC ?= $(makefile_dir)build/package/pbuilderrc
+PBUILDER_HOOKS_DIR ?= $(makefile_dir)build/package/pbuilder-hooks
+RPM_DEV_TREE ?= $(HOME)/rpmbuild
+
+# find Debian package version from the changelog file. latest version
+# should be at the top, first matching 'chkok (0.1.0-1) ...' and sed clears chars not in version
+CHKOK_DEB_VERSION := $(shell grep --only-matching --max-count 1 --perl-regexp "^\s*chkok\s+\(.+\)\s*" build/package/debian/changelog | sed 's/[^0-9.-]//g')
+CHKOK_DEB_UPSTREAM_VERSION := $(shell echo $(CHKOK_DEB_VERSION) | grep --only-matching --perl-regexp '^[0-9.]+')
+CHKOK_DEB_UPSTREAM_TARBAL_PATH := $(abspath $(makefile_dir)/..)
+CHKOK_DEB_UPSTREAM_TARBAL := $(CHKOK_DEB_UPSTREAM_TARBAL_PATH)/chkok_$(CHKOK_DEB_UPSTREAM_VERSION).orig.tar.gz
+DEB_BUILD_GIT_BRANCH := pkg-deb-$(CHKOK_DEB_VERSION)-$(TIMESTAMP_MINUTE)
+
+# find rpm version from the spec file. latest version
+# should be in the top tags, first matching 'Version: 0.1.0' and sed clears chars not in version
+CHKOK_RPM_VERSION := $(shell grep --only-matching --max-count 1 --line-regexp --perl-regexp "\s*Version\:\s*.+\s*" build/package/chkok.spec | sed 's/[^0-9.]//g')
+RPM_DEV_SRC_TGZ = $(RPM_DEV_TREE)/SOURCES/chkok-$(CHKOK_RPM_VERSION).tar.gz
+RPM_DEV_SPEC = $(RPM_DEV_TREE)/SPECS/chkok-$(CHKOK_RPM_VERSION).spec
+
+# command aliases
+cowbuilder = env DISTRIBUTION=$(DIST) ARCH=$(ARCH) BASEPATH=/var/cache/pbuilder/base-$(DIST)-$(ARCH).cow cowbuilder
+
+
+chkok:
+	GOOS=$(OS) GOARCH=$(GOARCH) go build -ldflags $(GOLDFLAGS) cmd/chkok.go
+
+
+build: chkok
+
+
+test:
+	go test -v -race ./...
+
+
+install: build
+	$(INSTALL_PROGRAM) -d $(DESTDIR)$(bindir)
+	$(INSTALL_PROGRAM) chkok $(DESTDIR)$(bindir)
+
+uninstall:
+	rm $(DESTDIR)$(bindir)/chkok
+
+clean:
+	rm -f chkok
+	go clean || true
+
+
+distclean: clean
+
+# override prefix so .deb package installs binaries to /usr/bin instead of /usr/local/bin
+pkg-deb: export prefix = /usr
+# requires a cowbuilder environment. see pkg-deb-setup
+pkg-deb:
+	git checkout -b $(DEB_BUILD_GIT_BRANCH)
+	rm -f $(CHKOK_DEB_UPSTREAM_TARBAL); tar --exclude-backups --exclude-vcs -zcf $(CHKOK_DEB_UPSTREAM_TARBAL) .
+	cp -r build/package/debian debian; git add debian; git commit -m 'add debian dir for packaging v$(CHKOK_DEB_VERSION)'
+	gbp buildpackage --git-ignore-new --git-verbose --git-pbuilder \
+			 --git-no-create-orig --git-tarball-dir=$(CHKOK_DEB_UPSTREAM_TARBAL_PATH) \
+			 --git-hooks \
+			 --git-dist=$(DIST) --git-arch=$(ARCH) \
+			 --git-ignore-new --git-ignore-branch \
+			 --git-pbuilder-options='--configfile=$(PBUILDER_RC) --hookdir=$(PBUILDER_HOOKS_DIR) --buildresult=$(PKG_DIST_DIR)' \
+			 -b -us -uc -sa
+	git checkout $(GIT_CURRENT_BRANCH)
+	git branch -D $(DEB_BUILD_GIT_BRANCH)
+
+# required:
+# sudo apt-get install build-essential debhelper pbuilder fakeroot cowbuilder git-buildpackage devscripts ubuntu-dev-tools
+pkg-deb-setup:
+	echo "creating a git-pbuilder environment with apt repositories to install new go versions ..."
+	DIST=$(DIST) ARCH=$(ARCH) git-pbuilder create --components=$(PBUILDER_COMPONENTS) \
+							--extrapackages="cowdancer curl wget" --configfile=$(PBUILDER_RC) \
+							--hookdir=$(PBUILDER_HOOKS_DIR)
+
+pkg-tgz: build
+	tar --create --gzip --exclude-vcs --exclude=docs/man/*.rst --file $(PKG_TGZ_PATH) chkok README.rst LICENSE
+
+# override prefix so .rpm package installs binaries to /usr/bin instead of /usr/local/bin
+pkg-rpm: export prefix = /usr
+# requires golang compiler > 1.13, and rpmdevtools package
+pkg-rpm:
+	(go version | grep -q 'go1.[01]') && (echo "please install Go lang tools > 1.20. aborting!" && /bin/false)
+	rm -f $(RPM_DEV_SRC_TGZ)
+	tar --exclude-vcs -zcf $(RPM_DEV_SRC_TGZ) .
+	cp build/package/chkok.spec $(RPM_DEV_SPEC)
+	rpmbuild -bs $(RPM_DEV_SPEC)
+	rpmbuild --rebuild $(RPM_DEV_TREE)/SRPMS/chkok-$(CHKOK_RPM_VERSION)*.src.rpm
+	find $(RPM_DEV_TREE)/RPMS -type f -readable -name 'chkok-$(CHKOK_RPM_VERSION)*.rpm' -exec mv '{}' $(PKG_DIST_DIR) \;
+
+pkg-clean:
+	rm -rf debian
+	rm -f $(PKG_TGZ_NAME)
+
+pkg-checksum:
+	if test -e $(PKG_TGZ_PATH); then cd $(PKG_DIST_DIR) \
+	    && (sed -i '/$(PKG_TGZ_NAME)/d' $(PKG_CHECKSUM_NAME) || true) \
+	    && $(SHA256SUM) $(PKG_TGZ_NAME) >> $(PKG_CHECKSUM_NAME); fi
+	if test -e $(PKG_DIST_DIR); then cd $(PKG_DIST_DIR) \
+	    && (sed -i '/chkok_$(CHKOK_DEB_VERSION).*deb/d' $(PKG_CHECKSUM_NAME) || true) \
+	    && find . -maxdepth 1 -readable -type f -name 'chkok_$(CHKOK_DEB_VERSION)*.deb' \
+	    -exec sha256sum '{}' \; >> $(PKG_CHECKSUM_NAME); fi
+	if test -e $(PKG_DIST_DIR); then cd $(PKG_DIST_DIR) \
+	    && (sed -i '/chkok-$(CHKOK_RPM_VERSION).*rpm/d' $(PKG_CHECKSUM_NAME) || true) \
+	    && find . -maxdepth 1 -readable -type f -name 'chkok-$(CHKOK_RPM_VERSION)*.rpm' \
+	    -exec sha256sum '{}' \; >> $(PKG_CHECKSUM_NAME); fi
+
+# sync version from source code to other files (docs, packaging, etc.)
+sync-version:
+	@ # update first occurrence of version in man page source and regen the man page
+	@ sed -i 's/^:Version:.*/:Version: $(CHKOK_VERSION)/;t' docs/man/chkok.rst && $(MAKE) docs
+	@ # update first occurrence of version  in RPM spec
+	@ sed -i 's/^Version:.*/Version: $(CHKOK_VERSION)/;t' build/package/chkok.spec
+	@ (grep --max 1 --only --perl-regexp '^chkok.+\(.+\).+' build/package/debian/changelog | grep -q -F $(CHKOK_VERSION)) || \
+	    echo -e "\e[33m*** NOTE:\e[m version $(CHKOK_VERSION) maybe missing from Debian changelog"
+	@ (grep --line-regexp '%changelog' -A 50 build/package/chkok.spec | grep -q -F $(CHKOK_VERSION)) || \
+	    echo -e "\e[33m*** NOTE:\e[m version $(CHKOK_VERSION) maybe missing from RPM changelog"
+
+# required: python docutils
+docs:
+	rst2man.py --input-encoding=utf8 --output-encoding=utf8 --strict docs/man/chkok.rst docs/man/chkok.1
+
+.DEFAULT_GOAL := build
+.PHONY: test build test-build install pkg-deb pkg-clean pkg-deb-setup pkg-tgz pkg-checksum sync-version docs

--- a/cmd/chkok.go
+++ b/cmd/chkok.go
@@ -10,8 +10,10 @@ import (
 	chkok "github.com/farzadghanei/chkok/internal"
 )
 
+const Version string = "0.1.0"
+
 // ModeHTTP run checks in http server mode
-const ModeHTTP = "http"
+const ModeHTTP string = "http"
 
 func main() {
 	var confPath string

--- a/cmd/chkok.go
+++ b/cmd/chkok.go
@@ -10,7 +10,7 @@ import (
 	chkok "github.com/farzadghanei/chkok/internal"
 )
 
-const Version string = "0.1.0"
+const Version string = "0.2.0"
 
 // ModeHTTP run checks in http server mode
 const ModeHTTP string = "http"
@@ -44,8 +44,9 @@ func run(confPath, mode string, output io.Writer, verbose bool) int {
 		fmt.Fprintf(output, "invalid configurations: %v", err)
 		return chkok.ExConfig
 	}
+	runnerConf, _ := chkok.GetConfRunner(&conf.Runners, mode)
 	if mode == ModeHTTP {
-		return chkok.RunModeHTTP(&checkGroups, conf, logger)
+		return chkok.RunModeHTTP(&checkGroups, &runnerConf, logger)
 	}
-	return chkok.RunModeCLI(&checkGroups, conf, output, logger)
+	return chkok.RunModeCLI(&checkGroups, &runnerConf, output, logger)
 }

--- a/cmd/chkok_test.go
+++ b/cmd/chkok_test.go
@@ -42,7 +42,7 @@ func TestRunHttp(t *testing.T) {
 	// Test the runner via an HTTP request
 	// Create a new request with a context
 	req, err := http.NewRequestWithContext(
-		context.Background(), http.MethodGet, "http://localhost:8080", http.NoBody)
+		context.Background(), http.MethodGet, "http://127.0.0.1:51234", http.NoBody)
 	if err != nil {
 		t.Fatalf("Failed to create HTTP request: %v", err)
 	}

--- a/cmd/chkok_test.go
+++ b/cmd/chkok_test.go
@@ -46,6 +46,7 @@ func TestRunHttp(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create HTTP request: %v", err)
 	}
+	req.Header.Set("X-Server-Shutdown", "test-shutdown-signal") // shutdown the server after the request
 
 	// Send the request multiple times, waiting for the server to
 	// start up and respond

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -4,6 +4,7 @@ runners:
   default:
     timeout: 5m
     shutdown_after_requests: 100  # mainly useful for testing http mode
+    listen_address: "127.0.0.1:51234"
 
 check_suites:
   etc:

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -3,8 +3,12 @@
 runners:
   default:
     timeout: 5m
-    shutdown_after_requests: 100  # mainly useful for testing http mode
     listen_address: "127.0.0.1:51234"
+  http:
+    # shutdown_signal_header is mainly useful for testing http mode, do not set it in production
+    # if set, better be treated like a secret, and a secure transport layer should be used.
+    # this is the value set on "X-Shutdown-Signal" header in the http request
+    # shutdown_signal_header: "test-shutdown-signal"
 
 check_suites:
   etc:

--- a/examples/test-http.yaml
+++ b/examples/test-http.yaml
@@ -6,7 +6,11 @@ runners:
     timeout: 1m
   http:
     timeout: 5s
+    listen_address: "127.0.0.1:51234"
     shutdown_after_requests: 1  # stop http server after 1 request, used for testing http mode
+    request_read_timeout: 2s
+    response_write_timeout: 2s
+
 
 check_suites:
   default:

--- a/examples/test-http.yaml
+++ b/examples/test-http.yaml
@@ -5,11 +5,14 @@ runners:
   default:
     timeout: 1m
   http:
-    timeout: 5s
     listen_address: "127.0.0.1:51234"
-    shutdown_after_requests: 1  # stop http server after 1 request, used for testing http mode
     request_read_timeout: 2s
     response_write_timeout: 2s
+    # shutdown_signal_header is mainly useful for testing http mode, do not set it in production
+    # if set, better be treated like a secret, and a secure transport layer should be used.
+    # this is the value set on "X-Shutdown-Signal" header in the http request
+    shutdown_signal_header: "test-shutdown-signal"
+    timeout: 5s
 
 
 check_suites:

--- a/internal/conf.go
+++ b/internal/conf.go
@@ -53,3 +53,48 @@ func ReadConf(path string) (*Conf, error) {
 	err = yaml.Unmarshal(contents, &conf)
 	return &conf, err
 }
+
+// GetConfRunner returns the runner config for the name merged with the default, and bool if it exists
+func GetConfRunner(runners *ConfRunners, name string) (ConfRunner, bool) {
+	defaultConf, defaultExists := (*runners)["default"]
+	namedConf, namedExists := (*runners)[name]
+
+	if !defaultExists && !namedExists {
+		return ConfRunner{}, false
+	}
+
+	if !defaultExists {
+		return namedConf, true
+	}
+
+	if !namedExists {
+		return defaultConf, true
+	}
+
+	// Merge the requested runner with the default runner
+	mergedConf := ConfRunner{
+		Timeout:               namedConf.Timeout,
+		ShutdownAfterRequests: namedConf.ShutdownAfterRequests,
+		ListenAddress:         namedConf.ListenAddress,
+		RequestReadTimeout:    namedConf.RequestReadTimeout,
+		ResponseWriteTimeout:  namedConf.ResponseWriteTimeout,
+	}
+
+	if mergedConf.Timeout == 0 {
+		mergedConf.Timeout = defaultConf.Timeout
+	}
+	if mergedConf.ShutdownAfterRequests == 0 {
+		mergedConf.ShutdownAfterRequests = defaultConf.ShutdownAfterRequests
+	}
+	if mergedConf.ListenAddress == "" {
+		mergedConf.ListenAddress = defaultConf.ListenAddress
+	}
+	if mergedConf.RequestReadTimeout == 0 {
+		mergedConf.RequestReadTimeout = defaultConf.RequestReadTimeout
+	}
+	if mergedConf.ResponseWriteTimeout == 0 {
+		mergedConf.ResponseWriteTimeout = defaultConf.ResponseWriteTimeout
+	}
+
+	return mergedConf, true
+}

--- a/internal/conf.go
+++ b/internal/conf.go
@@ -21,11 +21,11 @@ type Conf struct {
 
 // ConfRunner is config for the check runners
 type ConfRunner struct {
-	Timeout               time.Duration
-	ShutdownAfterRequests uint32        `yaml:"shutdown_after_requests"`
-	ListenAddress         string        `yaml:"listen_address"`
-	RequestReadTimeout    time.Duration `yaml:"request_read_timeout"`
-	ResponseWriteTimeout  time.Duration `yaml:"response_write_timeout"`
+	Timeout              time.Duration
+	ShutdownSignalHeader *string       `yaml:"shutdown_signal_header"`
+	ListenAddress        string        `yaml:"listen_address"`
+	RequestReadTimeout   time.Duration `yaml:"request_read_timeout"`
+	ResponseWriteTimeout time.Duration `yaml:"response_write_timeout"`
 }
 
 // ConfCheckSpec is the spec for each check configuration
@@ -73,18 +73,18 @@ func GetConfRunner(runners *ConfRunners, name string) (ConfRunner, bool) {
 
 	// Merge the requested runner with the default runner
 	mergedConf := ConfRunner{
-		Timeout:               namedConf.Timeout,
-		ShutdownAfterRequests: namedConf.ShutdownAfterRequests,
-		ListenAddress:         namedConf.ListenAddress,
-		RequestReadTimeout:    namedConf.RequestReadTimeout,
-		ResponseWriteTimeout:  namedConf.ResponseWriteTimeout,
+		Timeout:              namedConf.Timeout,
+		ShutdownSignalHeader: namedConf.ShutdownSignalHeader,
+		ListenAddress:        namedConf.ListenAddress,
+		RequestReadTimeout:   namedConf.RequestReadTimeout,
+		ResponseWriteTimeout: namedConf.ResponseWriteTimeout,
 	}
 
 	if mergedConf.Timeout == 0 {
 		mergedConf.Timeout = defaultConf.Timeout
 	}
-	if mergedConf.ShutdownAfterRequests == 0 {
-		mergedConf.ShutdownAfterRequests = defaultConf.ShutdownAfterRequests
+	if mergedConf.ShutdownSignalHeader == nil {
+		mergedConf.ShutdownSignalHeader = defaultConf.ShutdownSignalHeader
 	}
 	if mergedConf.ListenAddress == "" {
 		mergedConf.ListenAddress = defaultConf.ListenAddress

--- a/internal/conf.go
+++ b/internal/conf.go
@@ -22,7 +22,10 @@ type Conf struct {
 // ConfRunner is config for the check runners
 type ConfRunner struct {
 	Timeout               time.Duration
-	ShutdownAfterRequests uint32 `yaml:"shutdown_after_requests"`
+	ShutdownAfterRequests uint32        `yaml:"shutdown_after_requests"`
+	ListenAddress         string        `yaml:"listen_address"`
+	RequestReadTimeout    time.Duration `yaml:"request_read_timeout"`
+	ResponseWriteTimeout  time.Duration `yaml:"response_write_timeout"`
 }
 
 // ConfCheckSpec is the spec for each check configuration

--- a/internal/conf_test.go
+++ b/internal/conf_test.go
@@ -60,8 +60,71 @@ func TestReadConf(t *testing.T) {
 	}
 }
 
+func TestGetDefaultConfRunner(t *testing.T) {
+	// Test case where default key exists
+	wantReadTimeout := 60 * time.Second
+	wantWriteTimeout := 30 * time.Second
+	runners := ConfRunners{
+		"default": ConfRunner{
+			Timeout:              10 * time.Second,
+			ShutdownSignalHeader: nil,
+			ListenAddress:        "localhost:8081",
+			RequestReadTimeout:   wantReadTimeout,
+			ResponseWriteTimeout: wantWriteTimeout,
+			ResponseOK:           "YES",
+			ResponseFailed:       "NO",
+			ResponseTimeout:      "MAYBE",
+		},
+	}
+
+	defaultRunner := GetDefaultConfRunner(&runners)
+	if defaultRunner.Timeout != 10*time.Second {
+		t.Errorf("Expected Timeout to be 10s, got %v", defaultRunner.Timeout)
+	}
+	if defaultRunner.ListenAddress != "localhost:8081" {
+		t.Errorf("Expected ListenAddress to be localhost:8081, got %s", defaultRunner.ListenAddress)
+	}
+	if defaultRunner.RequestReadTimeout != wantReadTimeout {
+		t.Errorf("Expected RequestReadTimeout to be %v, got %v", wantReadTimeout,
+			defaultRunner.RequestReadTimeout)
+	}
+	if defaultRunner.ResponseWriteTimeout != wantWriteTimeout {
+		t.Errorf("Expected ResponseWriteTimeout to be %v, got %v", wantWriteTimeout,
+			defaultRunner.ResponseWriteTimeout)
+	}
+	if defaultRunner.ResponseOK != "YES" {
+		t.Errorf("Expected ResponseOK to be YES, got %s", defaultRunner.ResponseOK)
+	}
+	if defaultRunner.ResponseFailed != "NO" {
+		t.Errorf("Expected ResponseFailed to be NO, got %s", defaultRunner.ResponseFailed)
+	}
+	if defaultRunner.ResponseTimeout != "MAYBE" {
+		t.Errorf("Expected ResponseTimeout to be MAYBE, got %s", defaultRunner.ResponseTimeout)
+	}
+
+	// Test case where default key does not exist
+	runners = ConfRunners{}
+	defaultRunner = GetDefaultConfRunner(&runners)
+	if defaultRunner.Timeout != 0 {
+		t.Errorf("Expected Timeout to be 0, got %v", defaultRunner.Timeout)
+	}
+	if defaultRunner.ListenAddress != "127.0.0.1:8880" {
+		t.Errorf("Expected ListenAddress to be 127.0.0.1:8080, got %s", defaultRunner.ListenAddress)
+	}
+	if defaultRunner.ResponseOK != "OK" {
+		t.Errorf("Expected ResponseOK to be OK, got %s", defaultRunner.ResponseOK)
+	}
+	if defaultRunner.ResponseFailed != "FAILED" {
+		t.Errorf("Expected ResponseFailed to be FAILED, got %s", defaultRunner.ResponseFailed)
+	}
+	if defaultRunner.ResponseTimeout != "TIMEOUT" {
+		t.Errorf("Expected ResponseTimeout to be TIMEOUT, got %s", defaultRunner.ResponseTimeout)
+	}
+}
+
 func TestGetConfRunner(t *testing.T) {
 	var shutdownSignalHeader = "Test-Shutdown"
+
 	runners := ConfRunners{
 		"default": ConfRunner{
 			Timeout:       5 * time.Second,
@@ -76,6 +139,8 @@ func TestGetConfRunner(t *testing.T) {
 			ResponseWriteTimeout: 5 * time.Second,
 		},
 	}
+
+	defaultRunner := GetDefaultConfRunner(&runners)
 
 	tests := []struct {
 		name           string
@@ -92,31 +157,28 @@ func TestGetConfRunner(t *testing.T) {
 				ListenAddress:        "localhost:9090",
 				RequestReadTimeout:   5 * time.Second,
 				ResponseWriteTimeout: 5 * time.Second,
+				ResponseOK:           "OK",
+				ResponseFailed:       "FAILED",
+				ResponseTimeout:      "TIMEOUT",
 			},
 			expectedExists: true,
 		},
 		{
 			name:           "Non-existing runner",
 			runnerName:     "nonExistingRunner",
-			expectedRunner: runners["default"],
-			expectedExists: true,
+			expectedRunner: defaultRunner,
+			expectedExists: false,
 		},
 		{
-			name:       "Minimal http runner",
-			runnerName: "testMinimalHttpRunner",
-			expectedRunner: ConfRunner{
-				Timeout:              5 * time.Second,
-				ShutdownSignalHeader: nil,
-				ListenAddress:        "localhost:8080",
-				RequestReadTimeout:   0,
-				ResponseWriteTimeout: 0,
-			},
+			name:           "Minimal http runner",
+			runnerName:     "testMinimalHttpRunner",
+			expectedRunner: defaultRunner,
 			expectedExists: true,
 		},
 		{
 			name:           "Default runner",
 			runnerName:     "default",
-			expectedRunner: runners["default"],
+			expectedRunner: defaultRunner,
 			expectedExists: true,
 		},
 	}

--- a/internal/run_modes.go
+++ b/internal/run_modes.go
@@ -20,8 +20,8 @@ const (
 )
 
 // RunModeCLI run app in CLI mode using the provided configs, return exit code
-func RunModeCLI(checkGroups *CheckSuites, conf *Conf, output io.Writer, logger *log.Logger) int {
-	runner := Runner{Log: logger, Timeout: conf.Runners["default"].Timeout}
+func RunModeCLI(checkGroups *CheckSuites, conf *ConfRunner, output io.Writer, logger *log.Logger) int {
+	runner := Runner{Log: logger, Timeout: conf.Timeout}
 	passed, failed, timedout := runChecks(&runner, checkGroups, logger)
 	total := passed + failed + timedout
 	if timedout > 0 {
@@ -41,34 +41,12 @@ func httpRequestAsString(r *http.Request) string {
 }
 
 // RunModeHTTP runs app in http server mode using the provided config, return exit code
-func RunModeHTTP(checkGroups *CheckSuites, conf *Conf, logger *log.Logger) int {
-	timeout := conf.Runners["default"].Timeout
-	shutdownAfterRequests := conf.Runners["default"].ShutdownAfterRequests
-	listenAddress := conf.Runners["default"].ListenAddress
-	requestReadTimeout := conf.Runners["default"].RequestReadTimeout
-	responseWriteTimeout := conf.Runners["default"].ResponseWriteTimeout
-
-	// override default runner config if with http runner config if provided
-	if httpRunnerConf, ok := conf.Runners["http"]; ok {
-		if httpRunnerConf.Timeout > 0 {
-			timeout = httpRunnerConf.Timeout
-		}
-		if httpRunnerConf.ShutdownAfterRequests > 0 {
-			shutdownAfterRequests = httpRunnerConf.ShutdownAfterRequests
-		}
-		if httpRunnerConf.ShutdownAfterRequests > 0 {
-			shutdownAfterRequests = httpRunnerConf.ShutdownAfterRequests
-		}
-		if httpRunnerConf.ListenAddress != "" {
-			listenAddress = httpRunnerConf.ListenAddress
-		}
-		if httpRunnerConf.RequestReadTimeout > 0 {
-			requestReadTimeout = httpRunnerConf.RequestReadTimeout
-		}
-		if httpRunnerConf.ResponseWriteTimeout > 0 {
-			responseWriteTimeout = httpRunnerConf.ResponseWriteTimeout
-		}
-	}
+func RunModeHTTP(checkGroups *CheckSuites, conf *ConfRunner, logger *log.Logger) int {
+	timeout := conf.Timeout
+	shutdownAfterRequests := conf.ShutdownAfterRequests
+	listenAddress := conf.ListenAddress
+	requestReadTimeout := conf.RequestReadTimeout
+	responseWriteTimeout := conf.ResponseWriteTimeout
 
 	if listenAddress == "" {
 		logger.Printf("no http listen address provided, using default: %s", DefaultListenAddress)


### PR DESCRIPTION
- move defaults away from runner but to the config itself, use better defaults
- allow customizing the http mode response via new configurations
- change shutting down the http server in tests, to use a signal string header instead of counting requests